### PR TITLE
Handle a panic when another worker has already failed

### DIFF
--- a/rofs/downloader.go
+++ b/rofs/downloader.go
@@ -57,7 +57,7 @@ func (d *Downloader) DownloadBlock(block meta.BlockInfo) ([]byte, error) {
 func (d *Downloader) worker(ctx context.Context, feed <-chan *DownloadBlock, out chan<- *OutputBlock) {
 	defer func() {
 		if err := recover(); err != nil {
-			log.Errorf("recover from panic: %s", err)
+			log.Warningf("cancel block download: %s", err)
 		}
 	}()
 

--- a/rofs/downloader.go
+++ b/rofs/downloader.go
@@ -3,10 +3,10 @@ package rofs
 import (
 	"context"
 	"fmt"
-	"github.com/zero-os/0-fs/meta"
-	"github.com/zero-os/0-fs/storage"
 	"github.com/golang/snappy"
 	"github.com/xxtea/xxtea-go/xxtea"
+	"github.com/zero-os/0-fs/meta"
+	"github.com/zero-os/0-fs/storage"
 	"io/ioutil"
 	"math"
 	"os"
@@ -55,6 +55,12 @@ func (d *Downloader) DownloadBlock(block meta.BlockInfo) ([]byte, error) {
 }
 
 func (d *Downloader) worker(ctx context.Context, feed <-chan *DownloadBlock, out chan<- *OutputBlock) {
+	defer func() {
+		if err := recover(); err != nil {
+			log.Errorf("recover from panic: %s", err)
+		}
+	}()
+
 	for {
 		select {
 		case blk := <-feed:


### PR DESCRIPTION
When one of the download workers fails to get its chunk
this will cause the full download to cancel and close
the channel for the other workers, if another worker
is tried to send its chunk over the channel it will cause
a panic. we catch it not to cash the fs.